### PR TITLE
chore(dependabot): 🛠️ add configuration for npm and GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,53 @@
+version: 2
+updates:
+  # Enable version updates for npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
+    assignees:
+      - "yacosta738"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      astro:
+        patterns:
+          - "astro*"
+          - "@astrojs/*"
+      dev-dependencies:
+        dependency-type: "development"
+        patterns:
+          - "@types/*"
+          - "typescript"
+          - "biome"
+          - "lefthook"
+          - "vitest"
+          - "@vitest/*"
+      ui-dependencies:
+        patterns:
+          - "tailwind*"
+          - "@tailwindcss/*"
+          - "lucide*"
+      security-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    assignees:
+      - "yacosta738"
+    commit-message:
+      prefix: "ci"
+      include: "scope"


### PR DESCRIPTION
This pull request adds a new configuration file to enable and customize automated dependency updates using Dependabot. The configuration sets up scheduled updates for both npm dependencies and GitHub Actions, organizes updates into logical groups, and assigns responsibility for reviewing these updates.

Dependabot configuration:

* Added `.github/dependabot.yml` to enable weekly automated dependency updates for both npm packages and GitHub Actions, including grouping dependencies by type and assigning a reviewer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated weekly dependency updates for npm and GitHub Actions (Mondays, 09:00).
  * Limited concurrent update PRs (npm: 10; actions: 5) and auto-assigned a maintainer for review.
  * Standardized commit messages with scoped prefixes (“deps” for libraries, “ci” for workflows).
  * Grouped updates for easier review (Astro, development tools, UI libraries) and isolated security patch updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->